### PR TITLE
added goo magnet support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,7 @@ export function main(argString = ""): void {
       const coldResTarget = Math.floor((16 + todayTurnsSpent()) / 3);
       do {
         const forceEquip = [];
+		forceEquip.push($item`goo magnet`); 
         if (have($item`Lil' Doctor™ bag`) && get("_chestXRayUsed") < 3) {
           forceEquip.push($item`Lil' Doctor™ bag`);
         }


### PR DESCRIPTION
there's no check if you have it, since you shouldn't not have it.  (also while it's technically possible to have a single offhand grant enough +item to surpass the magnet, that would need to be over +200% at a minimum, which I don't think is possible)